### PR TITLE
[INF-4105] Bugfix for kong consumers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 )
 
-replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250204123635-45e67f28fe26
+replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250204134117-b896da55b4ba

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 )
 
-replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250204122644-3eb974415845
+replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250204123635-45e67f28fe26

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 )
 
-replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250204134117-b896da55b4ba
+replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250204152003-11abad056edf

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 )
 
-replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250115143942-1189ba47f135
+replace github.com/kevholditch/gokong => github.com/datacamp-engineering/gokong v1.9.1-0.20250204122644-3eb974415845

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250204123635-45e67f28fe26 h1:8nc00UVHtd5ddCJtyCvuZoEmc49mGFW83pj1/tENlNs=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250204123635-45e67f28fe26/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204134117-b896da55b4ba h1:tXDOpR5CWLrfTIWnGT7Uje1Ps4zaUQ4+q/j2uo4Ul90=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204134117-b896da55b4ba/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250204134117-b896da55b4ba h1:tXDOpR5CWLrfTIWnGT7Uje1Ps4zaUQ4+q/j2uo4Ul90=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250204134117-b896da55b4ba/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204152003-11abad056edf h1:Vfe80aX8arkNpStMRlCLn1xKGR7eKXXulto5JDEmW6E=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204152003-11abad056edf/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250115143942-1189ba47f135 h1:DYnTZ2u92UMN9KJn5GZ7ITXz1AVCTwslQHBp3LqapM8=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250115143942-1189ba47f135/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204122644-3eb974415845 h1:wc/0bYzBtn8rUC1gQKP4e5jS9MGmRXFn+cqYRRcEEwk=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204122644-3eb974415845/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250204122644-3eb974415845 h1:wc/0bYzBtn8rUC1gQKP4e5jS9MGmRXFn+cqYRRcEEwk=
-github.com/datacamp-engineering/gokong v1.9.1-0.20250204122644-3eb974415845/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204123635-45e67f28fe26 h1:8nc00UVHtd5ddCJtyCvuZoEmc49mGFW83pj1/tENlNs=
+github.com/datacamp-engineering/gokong v1.9.1-0.20250204123635-45e67f28fe26/go.mod h1:/yPEclE0cTiGmrhJK8Un8tHP1ZQ3hty35tTdbwYaXqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/kong/resource_kong_consumer_plugin_config.go
+++ b/kong/resource_kong_consumer_plugin_config.go
@@ -117,8 +117,9 @@ func resourceKongConsumerPluginConfigCreate(d *schema.ResourceData, meta interfa
 	consumerId := readStringFromResource(d, "consumer_id")
 	pluginName := readStringFromResource(d, "plugin_name")
 	configJson := readStringFromResource(d, "config_json")
+	tags := readStringArrayPtrFromResource(d, "tags")
 
-	consumerPluginConfig, err := meta.(*config).adminClient.Consumers().CreatePluginConfig(consumerId, pluginName, configJson)
+	consumerPluginConfig, err := meta.(*config).adminClient.Consumers().CreatePluginConfig(consumerId, pluginName, configJson, tags)
 	if err != nil {
 		return fmt.Errorf("failed to create kong consumer plugin config, error: %v", err)
 	}

--- a/kong/resource_kong_consumer_plugin_config.go
+++ b/kong/resource_kong_consumer_plugin_config.go
@@ -117,9 +117,8 @@ func resourceKongConsumerPluginConfigCreate(d *schema.ResourceData, meta interfa
 	consumerId := readStringFromResource(d, "consumer_id")
 	pluginName := readStringFromResource(d, "plugin_name")
 	configJson := readStringFromResource(d, "config_json")
-	tags := readStringArrayPtrFromResource(d, "tags")
 
-	consumerPluginConfig, err := meta.(*config).adminClient.Consumers().CreatePluginConfig(consumerId, pluginName, configJson, tags)
+	consumerPluginConfig, err := meta.(*config).adminClient.Consumers().CreatePluginConfig(consumerId, pluginName, configJson)
 	if err != nil {
 		return fmt.Errorf("failed to create kong consumer plugin config, error: %v", err)
 	}

--- a/kong/resource_kong_consumer_plugin_config.go
+++ b/kong/resource_kong_consumer_plugin_config.go
@@ -159,7 +159,6 @@ func resourceKongConsumerPluginConfigRead(d *schema.ResourceData, meta interface
 
 	d.Set("consumer_id", idFields.consumerId)
 	d.Set("plugin_name", idFields.pluginName)
-	d.Set("tags", consumerPluginConfig.Tags)
 
 	// We sync this property from upstream as a method to allow you to import a resource with the config tracked in
 	// terraform state. We do not track `config` as it will be a source of a perpetual diff.


### PR DESCRIPTION
Update to the latest version of the gokong module to fix a bug with the creation off consumer plugin config https://github.com/datacamp-engineering/gokong/pull/8

Removal of d.Set("tags", consumerPluginConfig.Tags) under resourceKongConsumerPluginConfigRead.
This tried to read a state field for tags under:
```
computed_config = jsonencode(
            {
              - group = "allowed_for_2f8edadd-b139-45b8-ab43-f6d20d1d136f"
              - tags  = null
            }
```
This field is however never populated by kong and is also not supposed to exist. So the `kong_consumer_plugin_config` kept being recreated as changes on the resource require a ForceNew. 

Tags will still be create for consumer plugins here: https://github.com/datacamp-engineering/gokong/blob/d9c435fce961494ceaf3d6a853d012273ba1fea5/consumers.go#L176

Validated by 
* deleting the `kong-basic-auth`
** https://concourse.ops.datacamp.com/teams/developer-tooling/pipelines/test/jobs/deploy%20test%20in%20staging/builds/627
* add the `kong-basic-auth` back 
** https://concourse.ops.datacamp.com/teams/developer-tooling/pipelines/test/jobs/deploy%20test%20in%20staging/builds/628
* Rerunning the pipeline -> No changes detected as expected
** https://concourse.ops.datacamp.com/teams/developer-tooling/pipelines/test/jobs/deploy%20test%20in%20staging/builds/629

Clear diff between old output:
```
-/+ resource "kong_consumer_plugin_config" "consumer_acl_config" {
      ~ computed_config = jsonencode(
            {
              - group = "allowed_for_2f8edadd-b139-45b8-ab43-f6d20d1d136f"
              - tags  = null
            }
        ) -> (known after apply)
      ~ id              = "0e1ac2c5-c9f8-41df-9ed8-b98ab0fa4ec5|acls|5b38ecc1-d912-4e38-b835-95ad2eb65cc3" -> (known after apply)
      ~ tags            = [ # forces replacement
          + "test-service",
        ]
        # (3 unchanged attributes hidden)
    }
```

And new output:
```
 + resource "kong_consumer_plugin_config" "consumer_acl_config" {
      + computed_config = (known after apply)
      + config_json     = jsonencode(
            {
              + group = "allowed_for_2f8edadd-b139-45b8-ab43-f6d20d1d136f"
            }
        )
      + consumer_id     = "0e1ac2c5-c9f8-41df-9ed8-b98ab0fa4ec5"
      + id              = (known after apply)
      + plugin_name     = "acls"
      + tags            = [
          + "test",
        ]
    }
```



